### PR TITLE
Compatibility with Chat Heads (and other mods)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,7 @@ group = project.maven_group
 repositories {
 	maven { url "https://maven.terraformersmc.com" } // modmenu
 	maven { url "https://maven.shedaniel.me/" } // cloth-config-fabric
+	mavenCentral()
 }
 
 dependencies {
@@ -25,6 +26,8 @@ dependencies {
 	modImplementation include("me.shedaniel.cloth:cloth-config-fabric:${project.cloth_config_version}") {
 		exclude(group: "net.fabricmc.fabric-api")
 	}
+
+	include(implementation(annotationProcessor("io.github.llamalad7:mixinextras-fabric:0.2.0")))
 }
 
 processResources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,10 +2,10 @@
 org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=1.20.1
-loader_version=0.14.21
+minecraft_version=1.20.2
+loader_version=0.14.24
 # Mod Properties
-mod_version=1.0.1+1.20.1
+mod_version=1.0.2+1.20.2
 maven_group=me.drex
 archives_base_name=cleanchat
 # Dependencies

--- a/src/main/java/me/drex/cleanchat/mixin/ChatComponentMixin.java
+++ b/src/main/java/me/drex/cleanchat/mixin/ChatComponentMixin.java
@@ -1,5 +1,8 @@
 package me.drex.cleanchat.mixin;
 
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import me.drex.cleanchat.CleanChatMod;
 import net.minecraft.client.GuiMessageTag;
 import net.minecraft.client.gui.GuiGraphics;
@@ -10,14 +13,14 @@ import org.spongepowered.asm.mixin.injection.*;
 @Mixin(ChatComponent.class)
 public abstract class ChatComponentMixin {
 
-    @Redirect(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/GuiMessageTag;icon()Lnet/minecraft/client/GuiMessageTag$Icon;"))
-    public GuiMessageTag.Icon removeIcon(GuiMessageTag original) {
-        return CleanChatMod.CHAT_CONFIG.disableIcons ? null : original.icon();
+    @ModifyExpressionValue(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/GuiMessageTag;icon()Lnet/minecraft/client/GuiMessageTag$Icon;"))
+    public GuiMessageTag.Icon removeIcon(GuiMessageTag.Icon original) {
+        return CleanChatMod.CHAT_CONFIG.disableIcons ? null : original;
     }
 
-    @Redirect(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/GuiGraphics;fill(IIIII)V", ordinal = 1))
-    public void removeBar(GuiGraphics guiGraphics, int i, int j, int k, int l, int m) {
-        if (!CleanChatMod.CHAT_CONFIG.disableBar) guiGraphics.fill(i, j, k, l, m);
+    @WrapOperation(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/GuiGraphics;fill(IIIII)V", ordinal = 1))
+    public void removeBar(GuiGraphics instance, int x1, int y1, int x2, int y2, int color, Operation<Void> original) {
+        if (!CleanChatMod.CHAT_CONFIG.disableBar) original.call(instance, x1, y1, x2, y2, color);
     }
 
     @ModifyArg(method = "render", at = @At(value = "INVOKE", target = "Lcom/mojang/blaze3d/vertex/PoseStack;translate(FFF)V", ordinal = 0), index = 0)
@@ -25,12 +28,12 @@ public abstract class ChatComponentMixin {
         return CleanChatMod.CHAT_CONFIG.disableBar ? 2 : original;
     }
 
-    @ModifyConstant(method = "screenToChatX", constant = @Constant(doubleValue = 4.0))
+    @ModifyExpressionValue(method = "screenToChatX", at = @At(value = "CONSTANT", args = "doubleValue=4.0"))
     public double adjustChatCoordinates(double original) {
         return CleanChatMod.CHAT_CONFIG.disableBar ? 2 : original;
     }
 
-    @ModifyConstant(method = "getTagIconLeft", constant = @Constant(intValue = 4))
+    @ModifyExpressionValue(method = "getTagIconLeft", at = @At(value = "CONSTANT", args = "intValue=4"))
     public int moveIcon(int original) {
         return CleanChatMod.CHAT_CONFIG.disableBar ? 2 : original;
     }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -35,7 +35,7 @@
   ],
   "depends": {
     "fabricloader": ">=0.14.6",
-    "minecraft": ">=1.19.1",
+    "minecraft": ">=1.20.1",
     "java": ">=17"
   },
   "suggests": {


### PR DESCRIPTION
Hey, Chat Heads maintainer here.
We've got a compatibility issue https://github.com/dzwdz/chat_heads/issues/74 due to wanting to both move the tag icon via a `@ModifyConstant`.

For context, the issue with `@ModifyConstant` and `@Redirect` is that only one mod/mixin can use them. The next mixin will fail to find the constant or method call, since it has already been replaced.
[MixinExtras](https://github.com/LlamaLad7/MixinExtras) is a great Mixin library with useful new mixins designed for mod compatibility.

`@ModifyExpressionValue` can be used as a drop in replacement for `@ModifyConstant` (with a slightly different syntax), which allows for chaining, basically replacing e.g. a constant `4` with `f(4)` and then `g(f(4))`.
It also works for changing return values of method calls, which I used to replace the first `removeIcon` `@Redirect`.
The second `removeBar` `@Redirect` is a prime example for a `@WrapOperation`, allowing to, well, wrap an operation, like adding an `if` around `guiGraphics.fill()` to only execute it conditionally.

I did test all the changes and it seems to work just fine.